### PR TITLE
Register ILoggerFactory

### DIFF
--- a/src/LoggingExtension.cs
+++ b/src/LoggingExtension.cs
@@ -26,9 +26,8 @@ namespace Unity.Microsoft.Logging
 
         [InjectionConstructor]
         public LoggingExtension()
-        {
-            LoggerFactory = new LoggerFactory();
-        }
+            : this(new LoggerFactory())
+        { }
 
         public LoggingExtension(ILoggerFactory factory)
         {
@@ -50,7 +49,8 @@ namespace Unity.Microsoft.Logging
 
         protected override void Initialize()
         {
-            Context.Policies.Set(typeof(ILogger),   UnityContainer.All, typeof(ResolveDelegateFactory), (ResolveDelegateFactory)GetResolver);
+            Context.Policies.Set(typeof(ILoggerFactory),   UnityContainer.All, typeof(ResolveDelegateFactory), (ResolveDelegateFactory)GetFactoryResolver);
+            Context.Policies.Set(typeof(ILogger), UnityContainer.All, typeof(ResolveDelegateFactory), (ResolveDelegateFactory)GetResolver);
             Context.Policies.Set(typeof(ILogger<>), UnityContainer.All, typeof(ResolveDelegateFactory), (ResolveDelegateFactory)GetResolverGeneric);
         }
 
@@ -58,6 +58,14 @@ namespace Unity.Microsoft.Logging
 
 
         #region IResolveDelegateFactory
+
+        public ResolveDelegate<BuilderContext> GetFactoryResolver(ref BuilderContext context)
+        {
+            return ((ref BuilderContext c) =>
+            {
+                return LoggerFactory;
+            });
+        }
 
         public ResolveDelegate<BuilderContext> GetResolver(ref BuilderContext context)
         {

--- a/tests/LoggingFixture.cs
+++ b/tests/LoggingFixture.cs
@@ -34,6 +34,12 @@ namespace Microsoft.Logging.Tests
         }
 
         [TestMethod]
+        public void microsoft_logging_factory_resolve_LoggerFactory()
+        {
+            Assert.IsNotNull(_container.Resolve<ILoggerFactory>());
+        }
+
+        [TestMethod]
         public void microsoft_logging_factory_CreateLogger_Category()
         {
             var factory = _container.Configure<LoggingExtension>().LoggerFactory;


### PR DESCRIPTION
I really couldn't find anything in the docs about how to work with `UnityContainerExtension` and policies. Since `ResolveDelegateFactory` implies using a factory (which we don't need since we already have a instance of `ILoggerFactory`) I guess this is not how it should be done. Please point me in the right direction if this isn't the way it should be!

At least all tests are passing ;)

Closes #5